### PR TITLE
Change to material icon

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -57,7 +57,7 @@
         "adminTab": {
             "singleton": false,
             "name": "Calendar",
-            "fa-icon": "fa-calendar"
+            "fa-icon": "calendar_today"
         },
         "dependencies": [
             {


### PR DESCRIPTION
Remnants of the FontAwesome have been eliminated. Added materialize icons for tab.